### PR TITLE
feat: BioMeasurement 도메인 및 CRUD 기능 추가

### DIFF
--- a/src/main/java/com/ieum/ieumbackend/bio_measurement/controller/BMController.java
+++ b/src/main/java/com/ieum/ieumbackend/bio_measurement/controller/BMController.java
@@ -1,0 +1,72 @@
+package com.ieum.ieumbackend.bio_measurement.controller;
+
+import com.ieum.ieumbackend.auth.domain.PrincipalDetails;
+import com.ieum.ieumbackend.auth.domain.User;
+import com.ieum.ieumbackend.bio_measurement.dto.BMRequestDto;
+import com.ieum.ieumbackend.bio_measurement.dto.BMResponseDto;
+import com.ieum.ieumbackend.bio_measurement.service.BMService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class BMController {
+
+    private final BMService bmService;
+
+    // CREATE
+    @PostMapping("/bio-measurements")
+    public ResponseEntity<BMResponseDto> createMeasurement(
+            @AuthenticationPrincipal PrincipalDetails principal,   // 로그인 유저
+            @RequestBody @Valid BMRequestDto bmRequestDto
+    ) {
+        if (principal == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build(); // principal 없는 경우 401 반환
+        }
+        User user = principal.getUser();
+        BMResponseDto created = bmService.createMeasurement(bmRequestDto, user);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    // READ (List)
+    @GetMapping("/bio-measurements")
+    public ResponseEntity<List<BMResponseDto>> getMeasurements(
+            @AuthenticationPrincipal PrincipalDetails principal,
+            @RequestParam(required = false) Long sessionId
+    ) {
+        if (principal == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        User user = principal.getUser();
+        List<BMResponseDto> list = bmService.getMeasurements(user, sessionId);
+        return ResponseEntity.ok(list);
+    }
+
+    // READ (Single)
+    @GetMapping("/bio-measurements/{id}")
+    public ResponseEntity<BMResponseDto> getMeasurement(@PathVariable Long id) {
+        return ResponseEntity.ok(bmService.getMeasurement(id));
+    }
+
+    // UPDATE
+    @PutMapping("/bio-measurements/{id}")
+    public ResponseEntity<BMResponseDto> updateMeasurement(
+            @PathVariable Long id,
+            @AuthenticationPrincipal PrincipalDetails principal,
+            @RequestBody @Valid BMRequestDto bmRequestDto
+    ) {
+        if (principal == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        User user = principal.getUser();
+        BMResponseDto updated = bmService.updateMeasurement(id, bmRequestDto, user);
+        return ResponseEntity.ok(updated);
+    }
+}

--- a/src/main/java/com/ieum/ieumbackend/bio_measurement/domain/BioMeasurement.java
+++ b/src/main/java/com/ieum/ieumbackend/bio_measurement/domain/BioMeasurement.java
@@ -1,5 +1,6 @@
 package com.ieum.ieumbackend.bio_measurement.domain;
 
+import com.ieum.ieumbackend.auth.domain.User;
 import com.ieum.ieumbackend.common.domain.TimeStamped;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
@@ -18,10 +19,12 @@ public class BioMeasurement extends TimeStamped {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
+    // User와의 다대일 관계 (N:1) - 여러 측정값이 한 유저에 속함
+    @ManyToOne(fetch = FetchType.LAZY)  // 필요 시 EAGER로도 가능
+    @JoinColumn(name = "user_id", nullable = false) // FK 지정
+    private User user;
 
-    // "한 번의 검사"를 식별하는 외래키(FK) - 12개의 입력을 한 세트로
+    // "한 번의 검사"를 구분하는 session_id
     @Column(name = "session_id", nullable = false)
     private Long sessionId;
 
@@ -46,4 +49,3 @@ public class BioMeasurement extends TimeStamped {
     public enum Organ { KIDNEY, SPLEEN, LUNG, HEART, LIVER, BLADDER }
     public enum Side { LEFT, RIGHT }
 }
-

--- a/src/main/java/com/ieum/ieumbackend/bio_measurement/dto/BMRequestDto.java
+++ b/src/main/java/com/ieum/ieumbackend/bio_measurement/dto/BMRequestDto.java
@@ -1,0 +1,20 @@
+package com.ieum.ieumbackend.bio_measurement.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class BMRequestDto {
+
+    private Long userId;
+    private Long sessionId;
+    private String organ;
+    private String side;
+    private Double value;
+    private LocalDateTime measuredAt;
+}

--- a/src/main/java/com/ieum/ieumbackend/bio_measurement/dto/BMResponseDto.java
+++ b/src/main/java/com/ieum/ieumbackend/bio_measurement/dto/BMResponseDto.java
@@ -1,0 +1,33 @@
+package com.ieum.ieumbackend.bio_measurement.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.ieum.ieumbackend.bio_measurement.domain.BioMeasurement;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class BMResponseDto {
+
+    private Long id;
+    private Long userId;
+    private Long sessionId;
+    private String organ;
+    private String side;
+    private Double value;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime measuredAt;
+
+    public BMResponseDto(BioMeasurement bm) {
+        this.id = bm.getId();
+        this.userId = bm.getUser().getId();
+        this.sessionId = bm.getSessionId();
+        this.organ = bm.getOrgan().name();
+        this.side = bm.getSide().name();
+        this.value = bm.getValue();
+        this.measuredAt = bm.getMeasuredAt();
+    }
+}

--- a/src/main/java/com/ieum/ieumbackend/bio_measurement/repository/BMRepository.java
+++ b/src/main/java/com/ieum/ieumbackend/bio_measurement/repository/BMRepository.java
@@ -1,0 +1,26 @@
+package com.ieum.ieumbackend.bio_measurement.repository;
+
+import com.ieum.ieumbackend.auth.domain.User;
+import com.ieum.ieumbackend.bio_measurement.domain.BioMeasurement;
+import com.ieum.ieumbackend.bio_measurement.domain.BioMeasurement.Organ;
+import com.ieum.ieumbackend.bio_measurement.domain.BioMeasurement.Side;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface BMRepository extends JpaRepository<BioMeasurement, Long> {
+
+    // 특정 유저의 모든 측정값을 최신순 조회
+    List<BioMeasurement> findByUserOrderByMeasuredAtDesc(User user);
+
+    // 특정 유저 + 세션의 측정값을 최신순 조회
+    List<BioMeasurement> findByUserAndSessionIdOrderByMeasuredAtDesc(User user, Long sessionId);
+
+    // 전체 측정값을 최신순으로 조회
+    List<BioMeasurement> findAllByOrderByMeasuredAtDesc();
+
+    // 중복 검사 (생성 시): 같은 세션 + organ + side 존재 여부
+    boolean existsBySessionIdAndOrganAndSide(Long sessionId, Organ organ, Side side);
+
+    // 중복 검사 (업데이트 시): 같은 세션 + organ + side 조합이 자기 자신 제외하고 존재 여부
+    boolean existsBySessionIdAndOrganAndSideAndIdNot(Long sessionId, Organ organ, Side side, Long id);
+}

--- a/src/main/java/com/ieum/ieumbackend/bio_measurement/service/BMService.java
+++ b/src/main/java/com/ieum/ieumbackend/bio_measurement/service/BMService.java
@@ -1,0 +1,14 @@
+package com.ieum.ieumbackend.bio_measurement.service;
+
+import com.ieum.ieumbackend.auth.domain.User;
+import com.ieum.ieumbackend.bio_measurement.dto.BMRequestDto;
+import com.ieum.ieumbackend.bio_measurement.dto.BMResponseDto;
+
+import java.util.List;
+
+public interface BMService {
+    BMResponseDto createMeasurement(BMRequestDto request, User user);
+    BMResponseDto getMeasurement(Long id);
+    List<BMResponseDto> getMeasurements(User user, Long sessionId);
+    BMResponseDto updateMeasurement(Long id, BMRequestDto request, User user);
+}

--- a/src/main/java/com/ieum/ieumbackend/bio_measurement/service/BMServiceImpl.java
+++ b/src/main/java/com/ieum/ieumbackend/bio_measurement/service/BMServiceImpl.java
@@ -1,0 +1,136 @@
+package com.ieum.ieumbackend.bio_measurement.service;
+
+import com.ieum.ieumbackend.auth.domain.User;
+import com.ieum.ieumbackend.bio_measurement.domain.BioMeasurement;
+import com.ieum.ieumbackend.bio_measurement.dto.BMRequestDto;
+import com.ieum.ieumbackend.bio_measurement.dto.BMResponseDto;
+import com.ieum.ieumbackend.bio_measurement.repository.BMRepository;
+
+import jakarta.persistence.EntityNotFoundException;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class BMServiceImpl implements BMService {
+
+    private final BMRepository bmRepository;
+
+    @Override
+    @Transactional
+    public BMResponseDto createMeasurement(BMRequestDto request, User user) {
+        BioMeasurement entity = new BioMeasurement();
+
+        // 로그인한 User 설정
+        entity.setUser(user);
+
+        entity.setSessionId(requireNonNull(request.getSessionId(), "sessionId"));
+        entity.setOrgan(parseOrgan(requireNonNull(request.getOrgan(), "organ")));
+        entity.setSide(parseSide(requireNonNull(request.getSide(), "side")));
+        entity.setValue(requireNonNull(request.getValue(), "value"));
+
+        LocalDateTime measuredAt = request.getMeasuredAt() != null
+                ? request.getMeasuredAt()
+                : LocalDateTime.now();
+        entity.setMeasuredAt(measuredAt);
+
+        // 중복 방지 체크
+        if (bmRepository.existsBySessionIdAndOrganAndSide(
+                entity.getSessionId(), entity.getOrgan(), entity.getSide())) {
+            throw new IllegalArgumentException(
+                    "이미 존재하는 측정값입니다: sessionId=" + entity.getSessionId()
+                            + ", organ=" + entity.getOrgan()
+                            + ", side=" + entity.getSide());
+        }
+
+        BioMeasurement saved = bmRepository.save(entity);
+        return new BMResponseDto(saved);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public BMResponseDto getMeasurement(Long id) {
+        BioMeasurement found = bmRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("BioMeasurement not found: id=" + id));
+        return new BMResponseDto(found);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<BMResponseDto> getMeasurements(User user, Long sessionId) {
+        List<BioMeasurement> list;
+        if (sessionId != null) {
+            list = bmRepository.findByUserAndSessionIdOrderByMeasuredAtDesc(user, sessionId);
+        } else {
+            list = bmRepository.findByUserOrderByMeasuredAtDesc(user);
+        }
+        return list.stream().map(BMResponseDto::new).toList();
+    }
+
+    @Override
+    @Transactional
+    public BMResponseDto updateMeasurement(Long id, BMRequestDto request, User user) {
+        BioMeasurement entity = bmRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("BioMeasurement not found: id=" + id));
+
+        // 해당 측정값이 로그인한 유저의 것인지 확인 (보안)
+        if (!entity.getUser().getId().equals(user.getId())) {
+            throw new SecurityException("본인 측정값만 수정할 수 있습니다.");
+        }
+
+        Long newSessionId = entity.getSessionId();
+        BioMeasurement.Organ newOrgan = entity.getOrgan();
+        BioMeasurement.Side newSide = entity.getSide();
+
+        boolean keyChanged = false;
+        if (request.getSessionId() != null) { newSessionId = request.getSessionId(); keyChanged = true; }
+        if (request.getOrgan() != null)      { newOrgan     = parseOrgan(request.getOrgan()); keyChanged = true; }
+        if (request.getSide() != null)       { newSide      = parseSide(request.getSide());   keyChanged = true; }
+
+        if (keyChanged && bmRepository.existsBySessionIdAndOrganAndSideAndIdNot(
+                newSessionId, newOrgan, newSide, id)) {
+            throw new IllegalArgumentException(
+                    "이미 존재하는 측정값입니다: sessionId=" + newSessionId
+                            + ", organ=" + newOrgan
+                            + ", side=" + newSide);
+        }
+
+        if (request.getSessionId() != null) entity.setSessionId(newSessionId);
+        if (request.getOrgan() != null) entity.setOrgan(newOrgan);
+        if (request.getSide() != null) entity.setSide(newSide);
+        if (request.getValue() != null) entity.setValue(request.getValue());
+        if (request.getMeasuredAt() != null) entity.setMeasuredAt(request.getMeasuredAt());
+
+        BioMeasurement updated = bmRepository.save(entity);
+        return new BMResponseDto(updated);
+    }
+
+    // ===== Helpers =====
+
+    private static <T> T requireNonNull(T value, String field) {
+        if (value == null) throw new IllegalArgumentException("필수 입력 값이 누락되었습니다: " + field);
+        return value;
+    }
+
+    private BioMeasurement.Organ parseOrgan(String raw) {
+        try {
+            return BioMeasurement.Organ.valueOf(raw.trim().toUpperCase());
+        } catch (Exception e) {
+            throw new IllegalArgumentException("유효하지 않은 organ 값: " + raw);
+        }
+    }
+
+    private BioMeasurement.Side parseSide(String raw) {
+        try {
+            return BioMeasurement.Side.valueOf(raw.trim().toUpperCase());
+        } catch (Exception e) {
+            throw new IllegalArgumentException("유효하지 않은 side 값: " + raw);
+        }
+    }
+}

--- a/src/main/java/com/ieum/ieumbackend/ml_service/dto/BioRequest.java
+++ b/src/main/java/com/ieum/ieumbackend/ml_service/dto/BioRequest.java
@@ -1,0 +1,18 @@
+package com.ieum.ieumbackend.ml_service.dto;
+
+import java.util.Map;
+
+public class BioRequest {
+    private Long userId;
+    private Long sessionId;
+    private Map<String, Double> measures;
+
+    public Long getUserId() { return userId; }
+    public void setUserId(Long userId) { this.userId = userId; }
+
+    public Long getSessionId() { return sessionId; }
+    public void setSessionId(Long sessionId) { this.sessionId = sessionId; }
+
+    public Map<String, Double> getMeasures() { return measures; }
+    public void setMeasures(Map<String, Double> measures) { this.measures = measures; }
+}


### PR DESCRIPTION
- BioMeasurement 엔티티 및 DTO(BMRequestDto, BMResponseDto) 구현
- BMRepository 작성 (DB 연동)
- BMService / BMServiceImpl 서비스 로직 추가
- BMController REST API 구현 (JWT 인증 기반)
- User 엔티티와 BioMeasurement 매핑(ORM) 적용